### PR TITLE
Extend qv to tracer dimension - Part 2b: SHOC Process

### DIFF
--- a/components/eamxx/src/physics/shoc/eamxx_shoc_process_interface.cpp
+++ b/components/eamxx/src/physics/shoc/eamxx_shoc_process_interface.cpp
@@ -2,6 +2,7 @@
 
 #include "share/property_checks/field_lower_bound_check.hpp"
 #include "share/property_checks/field_within_interval_check.hpp"
+#include "share/field/field_tracer_access.hpp"
 
 #include <ekat_assert.hpp>
 #include <ekat_team_policy_utils.hpp>
@@ -62,7 +63,11 @@ void SHOCMacrophysics::create_requests()
 
   add_field<Updated>("surf_evap",       scalar2d    , kg/(m2*s), grid_name);
   add_field<Updated> ("T_mid",          scalar3d_mid, K,         grid_name, ps);
-  add_tracer<Updated>("qv", m_grid, kg/kg, ps);
+
+  // qv now uses tracer-aware layout (tracer, col, lev)
+  // SCREAM_NUM_TRACERS is defined by CMake build system
+  auto qv_layout = m_grid->get_3d_tracer_layout(SCREAM_NUM_TRACERS);
+  add_field<Updated>("qv", qv_layout, kg/kg, grid_name, ps);
 
   // If TMS is a process, add surface drag coefficient to required fields
   if (m_params.get<bool>("apply_tms", false)) {
@@ -284,7 +289,11 @@ void SHOCMacrophysics::initialize_impl (const RunType run_type)
   const auto& surf_mom_flux       = get_field_in("surf_mom_flux").get_view<const Real**>();
   const auto& qtracers            = get_group_out("turbulence_advected_tracers").m_monolithic_field->get_strided_view<Pack***>();
   const auto& qc                  = get_field_out("qc").get_view<Pack**>();
-  const auto& qv                  = get_field_out("qv").get_view<Pack**>();
+
+  // qv now has tracer dimension (tracer, col, lev) - extract slot-0 bulk water via subview
+  const auto& qv_3d               = get_field_out("qv").get_view<Pack***>();
+  const auto& qv                  = get_tracer_bulk_subview(qv_3d);
+
   const auto& tke                 = get_field_out("tke").get_view<Pack**>();
   const auto& cldfrac_liq         = get_field_out("cldfrac_liq").get_view<Pack**>();
   const auto& cldfrac_liq_prev    = get_field_out("cldfrac_liq_prev").get_view<Pack**>();
@@ -613,7 +622,10 @@ void SHOCMacrophysics::check_flux_state_consistency(const double dt)
 
   const auto& pseudo_density = get_field_in ("pseudo_density").get_view<const Pack**>();
   const auto& surf_evap      = get_field_out("surf_evap").get_view<Real*>();
-  const auto& qv             = get_field_out("qv").get_view<Pack**>();
+
+  // qv has tracer dimension - extract slot-0 bulk water via subview
+  const auto& qv_3d          = get_field_out("qv").get_view<Pack***>();
+  const auto& qv             = get_tracer_bulk_subview(qv_3d);
 
   const auto nlevs           = m_num_levs;
   const auto nlev_packs      = ekat::npack<Pack>(nlevs);

--- a/components/eamxx/src/physics/shoc/impl/shoc_assumed_pdf_impl.hpp
+++ b/components/eamxx/src/physics/shoc/impl/shoc_assumed_pdf_impl.hpp
@@ -10,6 +10,12 @@ namespace scream {
 namespace shoc {
 
 /*
+ * NOTE (Water Tracers): qv field now has tracer dimension (tracer, col, lev).
+ * Interface layer extracts slot-0 bulk water via get_tracer_bulk_subview(),
+ * so kernels here receive 2D views (col, lev) and require no changes.
+ */
+
+/*
 Add some functions to avoid cuda compilation warnings
 TODO: move this to ekat or something
 */

--- a/components/eamxx/src/physics/shoc/impl/shoc_main_impl.hpp
+++ b/components/eamxx/src/physics/shoc/impl/shoc_main_impl.hpp
@@ -14,6 +14,10 @@ namespace shoc {
 /*
  * Implementation of shoc shoc_main. Clients should NOT
  * #include this file, but include shoc_functions.hpp instead.
+ *
+ * NOTE (Water Tracers): qv field now has tracer dimension (tracer, col, lev).
+ * Interface layer extracts slot-0 bulk water via get_tracer_bulk_subview(),
+ * so kernels here receive 2D views (col, lev) and require no changes.
  */
 
 template<typename S, typename D>

--- a/components/eamxx/src/physics/shoc/impl/shoc_pblintd_impl.hpp
+++ b/components/eamxx/src/physics/shoc/impl/shoc_pblintd_impl.hpp
@@ -9,6 +9,10 @@ namespace shoc {
 /*
  * Implementation of shoc pblintd. Clients should NOT
  * #include this file, but include shoc_functions.hpp instead.
+ *
+ * NOTE (Water Tracers): qv field now has tracer dimension (tracer, col, lev).
+ * Interface layer extracts slot-0 bulk water via get_tracer_bulk_subview(),
+ * so kernels here receive 2D views (col, lev) and require no changes.
  */
 
 //-----------------------------------------------------------------------

--- a/components/eamxx/tests/water_tracers/CMakeLists.txt
+++ b/components/eamxx/tests/water_tracers/CMakeLists.txt
@@ -15,3 +15,10 @@ EkatCreateUnitTest(test_tracer_access_patterns
   LIBS scream_share
   THREADS 1
 )
+
+# Test 3: SHOC qv field access with tracer dimension
+EkatCreateUnitTest(test_qv_shoc
+  SOURCES test_qv_shoc.cpp
+  LIBS scream_share
+  THREADS 1
+)

--- a/components/eamxx/tests/water_tracers/test_qv_shoc.cpp
+++ b/components/eamxx/tests/water_tracers/test_qv_shoc.cpp
@@ -1,0 +1,90 @@
+#include <catch2/catch.hpp>
+
+#include "share/field/field.hpp"
+#include "share/field/field_manager.hpp"
+#include "share/field/field_tracer_access.hpp"
+#include "share/grid/point_grid.hpp"
+#include "share/util/scream_setup_random_test.hpp"
+
+#include "ekat/ekat_pack_kokkos.hpp"
+#include "ekat/kokkos/ekat_kokkos_utils.hpp"
+
+namespace scream {
+
+TEST_CASE("shoc_qv_tracer_access", "[water_tracers][shoc]") {
+  using namespace ShortFieldTagsNames;
+  using Pack = ekat::Pack<Real, 1>;
+
+  // Create a simple grid
+  constexpr int ncols = 4;
+  constexpr int nlevs = 72;
+  #ifndef SCREAM_NUM_TRACERS
+  constexpr int ntracers = 1;
+  #else
+  constexpr int ntracers = SCREAM_NUM_TRACERS;
+  #endif
+
+  auto grid = create_point_grid("test_grid", ncols, nlevs, ncols);
+
+  // Create tracer-aware qv field
+  FieldIdentifier qv_fid("qv", grid->get_3d_tracer_layout(ntracers), ekat::units::kg/ekat::units::kg, grid->name());
+  Field qv_field(qv_fid);
+  qv_field.allocate_view();
+
+  // Get 3D tracer view and 2D bulk subview
+  auto qv_3d = qv_field.get_view<Pack***>();
+  auto qv_bulk = get_tracer_bulk_subview(qv_3d);
+
+  // Initialize slot-0 with test data
+  const Real test_value = 0.012; // kg/kg, typical atmospheric qv
+  Kokkos::deep_copy(qv_3d, 0.0);
+  Kokkos::parallel_for("init_qv_bulk", ncols * nlevs, KOKKOS_LAMBDA(int idx) {
+    int icol = idx / nlevs;
+    int ilev = idx % nlevs;
+    qv_bulk(icol, ilev)[0] = test_value;
+  });
+  Kokkos::fence();
+
+  // Verify SHOC can correctly read qv slot-0
+  bool all_correct = true;
+  Kokkos::parallel_reduce("verify_qv_access", ncols * nlevs,
+    KOKKOS_LAMBDA(int idx, bool& lcorrect) {
+      int icol = idx / nlevs;
+      int ilev = idx % nlevs;
+      const Real val = qv_bulk(icol, ilev)[0];
+      if (std::abs(val - test_value) > 1e-15) {
+        lcorrect = false;
+      }
+    }, Kokkos::LAnd<bool>(all_correct));
+  Kokkos::fence();
+
+  REQUIRE(all_correct);
+
+  // Test that slot-0 subview is independent from other tracer slots
+  if (ntracers > 1) {
+    const Real tracer1_value = 0.008;
+    Kokkos::parallel_for("init_qv_tracer1", ncols * nlevs, KOKKOS_LAMBDA(int idx) {
+      int icol = idx / nlevs;
+      int ilev = idx % nlevs;
+      qv_3d(1, icol, ilev)[0] = tracer1_value;
+    });
+    Kokkos::fence();
+
+    // Verify bulk (slot-0) unchanged
+    bool bulk_unchanged = true;
+    Kokkos::parallel_reduce("verify_bulk_unchanged", ncols * nlevs,
+      KOKKOS_LAMBDA(int idx, bool& lcorrect) {
+        int icol = idx / nlevs;
+        int ilev = idx % nlevs;
+        const Real val = qv_bulk(icol, ilev)[0];
+        if (std::abs(val - test_value) > 1e-15) {
+          lcorrect = false;
+        }
+      }, Kokkos::LAnd<bool>(bulk_unchanged));
+    Kokkos::fence();
+
+    REQUIRE(bulk_unchanged);
+  }
+}
+
+} // namespace scream


### PR DESCRIPTION
Update SHOC (PBL turbulence) to use tracer-aware qv field with SUBVIEW accessor pattern.

## Summary
- Update qv field registration in SHOC to use get_3d_tracer_layout(SCREAM_NUM_TRACERS)
- Extract slot-0 bulk water via get_tracer_bulk_subview() for kernel calls
- SHOC kernel implementations unchanged (receive 2D views via subview)
- Add unit test for SHOC qv tracer access

## Deliverables
- components/eamxx/src/physics/shoc/eamxx_shoc_process_interface.cpp
- components/eamxx/src/physics/shoc/impl/shoc_main_impl.hpp (documentation)
- components/eamxx/src/physics/shoc/impl/shoc_assumed_pdf_impl.hpp (documentation)
- components/eamxx/src/physics/shoc/impl/shoc_pblintd_impl.hpp (documentation)
- components/eamxx/tests/water_tracers/test_qv_shoc.cpp
- components/eamxx/tests/water_tracers/CMakeLists.txt

Part 3 of 8 of campaign 2026-05-29-wiso-group1-revised

Stacked on #4