### PR TITLE
Extend qv to tracer dimension - Part 2c: P3 Microphysics

### DIFF
--- a/components/eamxx/src/physics/p3/eamxx_p3_process_interface.cpp
+++ b/components/eamxx/src/physics/p3/eamxx_p3_process_interface.cpp
@@ -1,5 +1,6 @@
 #include "share/property_checks/field_within_interval_check.hpp"
 #include "share/property_checks/field_lower_bound_check.hpp"
+#include "share/field/field_tracer_access.hpp"
 #include "p3_functions.hpp"
 #include "eamxx_p3_process_interface.hpp"
 
@@ -75,7 +76,10 @@ void P3Microphysics::create_requests()
   add_field<Updated> ("T_mid",       scalar3d_layout_mid, K,      grid_name, ps);  // T_mid is the only one of these variables that is also updated.
 
   // Prognostic State:  (all fields are both input and output)
-  add_tracer<Updated>("qv", m_grid, kg/kg, ps);
+  // qv now uses tracer-aware layout (tracer, col, lev)
+  // SCREAM_NUM_TRACERS is defined by CMake build system
+  auto qv_layout = m_grid->get_3d_tracer_layout(SCREAM_NUM_TRACERS);
+  add_field<Updated>("qv", qv_layout, kg/kg, grid_name, ps);
   add_tracer<Updated>("qc", m_grid, kg/kg, ps);
   add_tracer<Updated>("qr", m_grid, kg/kg, ps);
   add_tracer<Updated>("qi", m_grid, kg/kg, ps);
@@ -310,7 +314,9 @@ void P3Microphysics::initialize_impl (const RunType /* run_type */)
     cld_frac_l_in = get_field_in("cldfrac_liq").get_view<const Pack **>();
     cld_frac_i_in = get_field_in("cldfrac_ice").get_view<const Pack **>();
   }
-  const  auto& qv             = get_field_out("qv").get_view<Pack**>();
+  // qv now has tracer dimension (tracer, col, lev) - extract slot-0 bulk water via subview
+  const  auto& qv_3d          = get_field_out("qv").get_view<Pack***>();
+  const  auto& qv             = get_tracer_bulk_subview(qv_3d);
   const  auto& qc             = get_field_out("qc").get_view<Pack**>();
   const  auto& nc             = get_field_out("nc").get_view<Pack**>();
   const  auto& qr             = get_field_out("qr").get_view<Pack**>();

--- a/components/eamxx/src/physics/p3/impl/p3_conservation_impl.hpp
+++ b/components/eamxx/src/physics/p3/impl/p3_conservation_impl.hpp
@@ -4,6 +4,12 @@
 #include "p3_functions.hpp"
 #include "share/physics/physics_constants.hpp"
 
+/*
+ * NOTE (Water Tracers): qv field now has tracer dimension (tracer, col, lev).
+ * Interface layer extracts slot-0 bulk water via get_tracer_bulk_subview(),
+ * so kernels here receive 2D views (col, lev) and require no changes.
+ */
+
 namespace scream {
 namespace p3 {
 

--- a/components/eamxx/src/physics/p3/impl/p3_evaporate_rain_impl.hpp
+++ b/components/eamxx/src/physics/p3/impl/p3_evaporate_rain_impl.hpp
@@ -4,6 +4,12 @@
 #include "p3_functions.hpp"
 #include "share/physics/physics_constants.hpp"
 
+/*
+ * NOTE (Water Tracers): qv field now has tracer dimension (tracer, col, lev).
+ * Interface layer extracts slot-0 bulk water via get_tracer_bulk_subview(),
+ * so kernels here receive 2D views (col, lev) and require no changes.
+ */
+
 namespace scream {
 namespace p3 {
 

--- a/components/eamxx/src/physics/p3/impl/p3_ice_deposition_sublimation_impl.hpp
+++ b/components/eamxx/src/physics/p3/impl/p3_ice_deposition_sublimation_impl.hpp
@@ -4,6 +4,12 @@
 #include "p3_functions.hpp"
 #include "share/physics/physics_constants.hpp"
 
+/*
+ * NOTE (Water Tracers): qv field now has tracer dimension (tracer, col, lev).
+ * Interface layer extracts slot-0 bulk water via get_tracer_bulk_subview(),
+ * so kernels here receive 2D views (col, lev) and require no changes.
+ */
+
 namespace scream {
 namespace p3 {
 

--- a/components/eamxx/src/physics/p3/impl/p3_main_impl.hpp
+++ b/components/eamxx/src/physics/p3/impl/p3_main_impl.hpp
@@ -14,6 +14,10 @@ namespace p3 {
 /*
  * Implementation of p3 main function. Clients should NOT #include
  * this file, #include p3_functions.hpp instead.
+ *
+ * NOTE (Water Tracers): qv field now has tracer dimension (tracer, col, lev).
+ * Interface layer extracts slot-0 bulk water via get_tracer_bulk_subview(),
+ * so kernels here receive 2D views (col, lev) and require no changes.
  */
 
 template <typename S, typename D>

--- a/components/eamxx/tests/water_tracers/CMakeLists.txt
+++ b/components/eamxx/tests/water_tracers/CMakeLists.txt
@@ -22,3 +22,10 @@ EkatCreateUnitTest(test_qv_shoc
   LIBS scream_share
   THREADS 1
 )
+
+# Test 4: P3 qv field access with tracer dimension
+EkatCreateUnitTest(test_qv_p3
+  SOURCES test_qv_p3.cpp
+  LIBS scream_share
+  THREADS 1
+)

--- a/components/eamxx/tests/water_tracers/test_qv_p3.cpp
+++ b/components/eamxx/tests/water_tracers/test_qv_p3.cpp
@@ -1,0 +1,90 @@
+#include <catch2/catch.hpp>
+
+#include "share/field/field.hpp"
+#include "share/field/field_manager.hpp"
+#include "share/field/field_tracer_access.hpp"
+#include "share/grid/point_grid.hpp"
+#include "share/util/scream_setup_random_test.hpp"
+
+#include "ekat/ekat_pack_kokkos.hpp"
+#include "ekat/kokkos/ekat_kokkos_utils.hpp"
+
+namespace scream {
+
+TEST_CASE("p3_qv_tracer_access", "[water_tracers][p3]") {
+  using namespace ShortFieldTagsNames;
+  using Pack = ekat::Pack<Real, 1>;
+
+  // Create a simple grid
+  constexpr int ncols = 4;
+  constexpr int nlevs = 72;
+  #ifndef SCREAM_NUM_TRACERS
+  constexpr int ntracers = 1;
+  #else
+  constexpr int ntracers = SCREAM_NUM_TRACERS;
+  #endif
+
+  auto grid = create_point_grid("test_grid", ncols, nlevs, ncols);
+
+  // Create tracer-aware qv field
+  FieldIdentifier qv_fid("qv", grid->get_3d_tracer_layout(ntracers), ekat::units::kg/ekat::units::kg, grid->name());
+  Field qv_field(qv_fid);
+  qv_field.allocate_view();
+
+  // Get 3D tracer view and 2D bulk subview
+  auto qv_3d = qv_field.get_view<Pack***>();
+  auto qv_bulk = get_tracer_bulk_subview(qv_3d);
+
+  // Initialize slot-0 with test data
+  const Real test_value = 0.012; // kg/kg, typical atmospheric qv
+  Kokkos::deep_copy(qv_3d, 0.0);
+  Kokkos::parallel_for("init_qv_bulk", ncols * nlevs, KOKKOS_LAMBDA(int idx) {
+    int icol = idx / nlevs;
+    int ilev = idx % nlevs;
+    qv_bulk(icol, ilev)[0] = test_value;
+  });
+  Kokkos::fence();
+
+  // Verify P3 can correctly read qv slot-0
+  bool all_correct = true;
+  Kokkos::parallel_reduce("verify_qv_access", ncols * nlevs,
+    KOKKOS_LAMBDA(int idx, bool& lcorrect) {
+      int icol = idx / nlevs;
+      int ilev = idx % nlevs;
+      const Real val = qv_bulk(icol, ilev)[0];
+      if (std::abs(val - test_value) > 1e-15) {
+        lcorrect = false;
+      }
+    }, Kokkos::LAnd<bool>(all_correct));
+  Kokkos::fence();
+
+  REQUIRE(all_correct);
+
+  // Test that slot-0 subview is independent from other tracer slots
+  if (ntracers > 1) {
+    const Real tracer1_value = 0.008;
+    Kokkos::parallel_for("init_qv_tracer1", ncols * nlevs, KOKKOS_LAMBDA(int idx) {
+      int icol = idx / nlevs;
+      int ilev = idx % nlevs;
+      qv_3d(1, icol, ilev)[0] = tracer1_value;
+    });
+    Kokkos::fence();
+
+    // Verify bulk (slot-0) unchanged
+    bool bulk_unchanged = true;
+    Kokkos::parallel_reduce("verify_bulk_unchanged", ncols * nlevs,
+      KOKKOS_LAMBDA(int idx, bool& lcorrect) {
+        int icol = idx / nlevs;
+        int ilev = idx % nlevs;
+        const Real val = qv_bulk(icol, ilev)[0];
+        if (std::abs(val - test_value) > 1e-15) {
+          lcorrect = false;
+        }
+      }, Kokkos::LAnd<bool>(bulk_unchanged));
+    Kokkos::fence();
+
+    REQUIRE(bulk_unchanged);
+  }
+}
+
+} // namespace scream


### PR DESCRIPTION
## Summary

- Extend P3 (microphysics) to use tracer-aware qv field
- Follow SUBVIEW accessor pattern from spec 2a
- Apply pattern established in spec 2b (SHOC)
- Interface extracts slot-0 bulk water; kernels receive 2D views unchanged

## Changes

**Field registration:**
- Update `eamxx_p3_process_interface.cpp` to use `get_3d_tracer_layout(SCREAM_NUM_TRACERS)` for qv

**Kernel interface:**
- Extract slot-0 bulk water via `get_tracer_bulk_subview()` in process interface
- Pass 2D subview to P3 kernels (no kernel changes required)

**Kernel implementations:**
- Add tracer dimension note to relevant impl headers
- No functional changes to kernel logic

**Testing:**
- Unit test for qv field access pattern
- P3 standalone tests must pass BFB
- Integration tests must pass BFB

## Test Plan

- [ ] Compile with SCREAM_NUM_TRACERS=1
- [ ] Unit test `test_qv_p3` passes
- [ ] P3 standalone tests pass BFB vs pre-campaign baseline
- [ ] P3 integration tests pass BFB
- [ ] Compile with SCREAM_NUM_TRACERS=3

## Context

Part 4 of 8 of campaign 2026-05-29-wiso-group1-revised
Stacked on #5 (spec 2b SHOC)