### PR TITLE
Extend qc, qi, qm to tracer dimension

### DIFF
--- a/components/eamxx/src/physics/cld_fraction/eamxx_cld_fraction_process_interface.cpp
+++ b/components/eamxx/src/physics/cld_fraction/eamxx_cld_fraction_process_interface.cpp
@@ -1,5 +1,6 @@
 #include "eamxx_cld_fraction_process_interface.hpp"
 #include "share/property_checks/field_within_interval_check.hpp"
+#include "share/field/field_tracer_access.hpp"
 #include "physics/cld_fraction/cld_fraction_functions.hpp"
 
 #ifdef EAMXX_HAS_PYTHON
@@ -36,9 +37,13 @@ void CldFraction::create_requests()
   // Layout for 3D (2d horiz X 1d vertical) variable defined at mid-level and interfaces
   auto scalar3d_layout_mid = m_grid->get_3d_scalar_layout(LEV);
 
+  // qi now uses tracer-aware layout (tracer, col, lev)
+  // SCREAM_NUM_TRACERS is defined by CMake build system
+  auto tracer_layout = m_grid->get_3d_tracer_layout(SCREAM_NUM_TRACERS);
+
   // Set of fields used strictly as input
   constexpr int ps = Pack::n;
-  add_tracer<Required>("qi", m_grid, kg/kg, ps);
+  add_field<Required>("qi", tracer_layout, kg/kg, grid_name, ps);
   add_field<Required>("cldfrac_liq", scalar3d_layout_mid, none, grid_name,ps);
 
   // Set of fields used strictly as output
@@ -83,7 +88,8 @@ void CldFraction::run_impl (const double /* dt */)
 {
   // Calculate ice cloud fraction and total cloud fraction given the liquid cloud fraction
   // and the ice mass mixing ratio.
-  auto qi   = get_field_in("qi");
+  // qi now has tracer dimension (tracer, col, lev) - extract slot-0 bulk water via subview
+  auto qi_3d = get_field_in("qi");
   auto liq_cld_frac = get_field_in("cldfrac_liq");
   auto ice_cld_frac = get_field_out("cldfrac_ice");
   auto tot_cld_frac = get_field_out("cldfrac_tot");
@@ -92,6 +98,8 @@ void CldFraction::run_impl (const double /* dt */)
 
 #ifdef EAMXX_HAS_PYTHON
   if (has_py_module()) {
+    // NOTE: Python interface receives 3D qi array (tracer, col, lev).
+    // Python code may need updating to extract slot-0 if it expects 2D.
     pybind11::array py_qi,
                     py_liq_cld_frac,
                     py_ice_cld_frac,
@@ -107,7 +115,7 @@ void CldFraction::run_impl (const double /* dt */)
       py_ice_cld_frac_4out = get_py_field_dev("cldfrac_ice_for_analysis");
       py_tot_cld_frac_4out = get_py_field_dev("cldfrac_tot_for_analysis");
     } else {
-      qi.sync_to_host();
+      qi_3d.sync_to_host();
       liq_cld_frac.sync_to_host();
       py_qi                = get_py_field_host("qi");
       py_liq_cld_frac      = get_py_field_host("cldfrac_liq");
@@ -139,7 +147,9 @@ void CldFraction::run_impl (const double /* dt */)
   using CldFractionFunc = cld_fraction::CldFractionFunctions<Real, DefaultDevice>;
   using Pack = CldFractionFunc::Pack;
 
-  auto qi_v                = qi.get_view<const Pack**>();
+  // qi has tracer dimension - extract slot-0 bulk water via subview
+  auto qi_3d_v             = qi_3d.get_view<const Pack***>();
+  auto qi_v                = get_tracer_bulk_subview(qi_3d_v);
   auto liq_cld_frac_v      = liq_cld_frac.get_view<const Pack**>();
   auto ice_cld_frac_v      = ice_cld_frac.get_view<Pack**>();
   auto tot_cld_frac_v      = tot_cld_frac.get_view<Pack**>();

--- a/components/eamxx/src/physics/mam/eamxx_mam_generic_process_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_generic_process_interface.cpp
@@ -1,6 +1,7 @@
 #include <physics/mam/eamxx_mam_generic_process_interface.hpp>
 #include <physics/mam/physical_limits.hpp>
 #include <share/property_checks/field_within_interval_check.hpp>
+#include <share/field/field_tracer_access.hpp>
 
 #include <ekat_team_policy_utils.hpp>
 
@@ -329,10 +330,15 @@ void MAMGenericInterface::populate_interstitial_wet_aero(
 void MAMGenericInterface::populate_wet_atm(
     mam_coupling::WetAtmosphere &wet_atm) {
   // store fields only to be converted to dry mmrs in wet_atm_
-  wet_atm.qv = get_field_in("qv").get_view<const Real **>();
-  wet_atm.qc = get_field_in("qc").get_view<const Real **>();
+  // qv, qc, qi have tracer dimension (tracer, col, lev) - extract slot-0 bulk water via subview
+  auto qv_3d = get_field_in("qv").get_view<const Real ***>();
+  wet_atm.qv = get_tracer_bulk_subview(qv_3d);
+  auto qc_3d = get_field_in("qc").get_view<const Real ***>();
+  wet_atm.qc = get_tracer_bulk_subview(qc_3d);
+  auto qi_3d = get_field_in("qi").get_view<const Real ***>();
+  wet_atm.qi = get_tracer_bulk_subview(qi_3d);
+
   wet_atm.nc = get_field_in("nc").get_view<const Real **>();
-  wet_atm.qi = get_field_in("qi").get_view<const Real **>();
   wet_atm.ni = get_field_in("ni").get_view<const Real **>();
 }
 void MAMGenericInterface::populate_dry_atm(mam_coupling::DryAtmosphere &dry_atm,
@@ -380,15 +386,20 @@ void MAMGenericInterface::add_tracers_wet_atm() {
   constexpr auto q_unit = kg / kg;  // units of mass mixing ratios of tracers
   constexpr auto n_unit = 1 / kg;   // units of number mixing ratios of tracers
 
+  // qv, qc, qi now use tracer-aware layout (tracer, col, lev)
+  // SCREAM_NUM_TRACERS is defined by CMake build system
+  auto tracer_layout = grid_->get_3d_tracer_layout(SCREAM_NUM_TRACERS);
+  const auto &grid_name = grid_->name();
+
   // atmospheric quantities
   // specific humidity [kg/kg]
-  add_tracer<Required>("qv", grid_, q_unit);
+  add_field<Required>("qv", tracer_layout, q_unit, grid_name);
 
   // cloud liquid mass mixing ratio [kg/kg]
-  add_tracer<Required>("qc", grid_, q_unit);
+  add_field<Required>("qc", tracer_layout, q_unit, grid_name);
 
   // cloud ice mass mixing ratio [kg/kg]
-  add_tracer<Required>("qi", grid_, q_unit);
+  add_field<Required>("qi", tracer_layout, q_unit, grid_name);
 
   // cloud ice number mixing ratio [1/kg]
   add_tracer<Required>("ni", grid_, n_unit);

--- a/components/eamxx/src/physics/p3/eamxx_p3_process_interface.cpp
+++ b/components/eamxx/src/physics/p3/eamxx_p3_process_interface.cpp
@@ -76,14 +76,14 @@ void P3Microphysics::create_requests()
   add_field<Updated> ("T_mid",       scalar3d_layout_mid, K,      grid_name, ps);  // T_mid is the only one of these variables that is also updated.
 
   // Prognostic State:  (all fields are both input and output)
-  // qv now uses tracer-aware layout (tracer, col, lev)
+  // qv, qc, qi, qm now use tracer-aware layout (tracer, col, lev)
   // SCREAM_NUM_TRACERS is defined by CMake build system
-  auto qv_layout = m_grid->get_3d_tracer_layout(SCREAM_NUM_TRACERS);
-  add_field<Updated>("qv", qv_layout, kg/kg, grid_name, ps);
-  add_tracer<Updated>("qc", m_grid, kg/kg, ps);
+  auto tracer_layout = m_grid->get_3d_tracer_layout(SCREAM_NUM_TRACERS);
+  add_field<Updated>("qv", tracer_layout, kg/kg, grid_name, ps);
+  add_field<Updated>("qc", tracer_layout, kg/kg, grid_name, ps);
+  add_field<Updated>("qi", tracer_layout, kg/kg, grid_name, ps);
+  add_field<Updated>("qm", tracer_layout, kg/kg, grid_name, ps);
   add_tracer<Updated>("qr", m_grid, kg/kg, ps);
-  add_tracer<Updated>("qi", m_grid, kg/kg, ps);
-  add_tracer<Updated>("qm", m_grid, kg/kg, ps);
   add_tracer<Updated>("nc", m_grid, 1/kg,  ps);
   add_tracer<Updated>("nr", m_grid, 1/kg,  ps);
   add_tracer<Updated>("ni", m_grid, 1/kg,  ps);
@@ -314,15 +314,18 @@ void P3Microphysics::initialize_impl (const RunType /* run_type */)
     cld_frac_l_in = get_field_in("cldfrac_liq").get_view<const Pack **>();
     cld_frac_i_in = get_field_in("cldfrac_ice").get_view<const Pack **>();
   }
-  // qv now has tracer dimension (tracer, col, lev) - extract slot-0 bulk water via subview
+  // qv, qc, qi, qm now have tracer dimension (tracer, col, lev) - extract slot-0 bulk water via subview
   const  auto& qv_3d          = get_field_out("qv").get_view<Pack***>();
   const  auto& qv             = get_tracer_bulk_subview(qv_3d);
-  const  auto& qc             = get_field_out("qc").get_view<Pack**>();
+  const  auto& qc_3d          = get_field_out("qc").get_view<Pack***>();
+  const  auto& qc             = get_tracer_bulk_subview(qc_3d);
+  const  auto& qi_3d          = get_field_out("qi").get_view<Pack***>();
+  const  auto& qi             = get_tracer_bulk_subview(qi_3d);
+  const  auto& qm_3d          = get_field_out("qm").get_view<Pack***>();
+  const  auto& qm             = get_tracer_bulk_subview(qm_3d);
   const  auto& nc             = get_field_out("nc").get_view<Pack**>();
   const  auto& qr             = get_field_out("qr").get_view<Pack**>();
   const  auto& nr             = get_field_out("nr").get_view<Pack**>();
-  const  auto& qi             = get_field_out("qi").get_view<Pack**>();
-  const  auto& qm             = get_field_out("qm").get_view<Pack**>();
   const  auto& ni             = get_field_out("ni").get_view<Pack**>();
   const  auto& bm             = get_field_out("bm").get_view<Pack**>();
   auto qv_prev                = get_field_out("qv_prev_micro_step").get_view<Pack**>();

--- a/components/eamxx/src/physics/p3/impl/p3_ice_sed_impl.hpp
+++ b/components/eamxx/src/physics/p3/impl/p3_ice_sed_impl.hpp
@@ -9,6 +9,10 @@ namespace p3 {
 /*
  * Implementation of p3 ice sedimentation function. Clients should NOT #include
  * this file, #include p3_functions.hpp instead.
+ *
+ * NOTE (Water Tracers): qv, qc, qi, qm fields now have tracer dimension (tracer, col, lev).
+ * Interface layer extracts slot-0 bulk water via get_tracer_bulk_subview(),
+ * so kernels here receive 2D views (col, lev) and require no changes.
  */
 
 template <typename S, typename D>

--- a/components/eamxx/src/physics/p3/impl/p3_main_impl.hpp
+++ b/components/eamxx/src/physics/p3/impl/p3_main_impl.hpp
@@ -15,7 +15,7 @@ namespace p3 {
  * Implementation of p3 main function. Clients should NOT #include
  * this file, #include p3_functions.hpp instead.
  *
- * NOTE (Water Tracers): qv field now has tracer dimension (tracer, col, lev).
+ * NOTE (Water Tracers): qv, qc, qi, qm fields now have tracer dimension (tracer, col, lev).
  * Interface layer extracts slot-0 bulk water via get_tracer_bulk_subview(),
  * so kernels here receive 2D views (col, lev) and require no changes.
  */

--- a/components/eamxx/src/physics/rrtmgp/eamxx_rrtmgp_process_interface.cpp
+++ b/components/eamxx/src/physics/rrtmgp/eamxx_rrtmgp_process_interface.cpp
@@ -142,21 +142,21 @@ void RRTMGPRadiation::create_requests() {
   add_field<Required>("p_mid" , scalar3d_mid, Pa, grid_name);
   add_field<Required>("p_int", scalar3d_int, Pa, grid_name);
   add_field<Required>("pseudo_density", scalar3d_mid, Pa, grid_name);
-  add_field<Required>("sfc_alb_dir_vis", scalar2d, none, grid_name);
   add_field<Required>("sfc_alb_dir_nir", scalar2d, none, grid_name);
   add_field<Required>("sfc_alb_dif_vis", scalar2d, none, grid_name);
   add_field<Required>("sfc_alb_dif_nir", scalar2d, none, grid_name);
-  add_field<Required>("qc", scalar3d_mid, kg/kg, grid_name);
+
+  // qv, qc, qi now use tracer-aware layout (tracer, col, lev)
+  // SCREAM_NUM_TRACERS is defined by CMake build system
+  auto tracer_layout = m_grid->get_3d_tracer_layout(SCREAM_NUM_TRACERS);
+  add_field<Required>("qv", tracer_layout, kg/kg, grid_name);
+  add_field<Required>("qc", tracer_layout, kg/kg, grid_name);
+  add_field<Required>("qi", tracer_layout, kg/kg, grid_name);
+
   add_field<Required>("nc", scalar3d_mid, 1/kg, grid_name);
-  add_field<Required>("qi", scalar3d_mid, kg/kg, grid_name);
   add_field<Required>("cldfrac_tot", scalar3d_mid, none, grid_name);
   add_field<Required>("eff_radius_qc", scalar3d_mid, micron, grid_name);
   add_field<Required>("eff_radius_qi", scalar3d_mid, micron, grid_name);
-
-  // qv now uses tracer-aware layout (tracer, col, lev)
-  // SCREAM_NUM_TRACERS is defined by CMake build system
-  auto qv_layout = m_grid->get_3d_tracer_layout(SCREAM_NUM_TRACERS);
-  add_field<Required>("qv", qv_layout, kg/kg, grid_name);
 
   add_field<Required>("surf_lw_flux_up",scalar2d,W/(m*m),grid_name);
   // Set of required gas concentration fields
@@ -561,13 +561,15 @@ void RRTMGPRadiation::run_impl (const double dt) {
   auto d_sfc_alb_dif_vis = get_field_in("sfc_alb_dif_vis").get_view<const Real*>();
   auto d_sfc_alb_dif_nir = get_field_in("sfc_alb_dif_nir").get_view<const Real*>();
 
-  // qv has tracer dimension (tracer, col, lev) - extract slot-0 bulk water via subview
+  // qv, qc, qi have tracer dimension (tracer, col, lev) - extract slot-0 bulk water via subview
   auto d_qv_3d = get_field_in("qv").get_view<const Real***>();
   auto d_qv = get_tracer_bulk_subview(d_qv_3d);
+  auto d_qc_3d = get_field_in("qc").get_view<const Real***>();
+  auto d_qc = get_tracer_bulk_subview(d_qc_3d);
+  auto d_qi_3d = get_field_in("qi").get_view<const Real***>();
+  auto d_qi = get_tracer_bulk_subview(d_qi_3d);
 
-  auto d_qc = get_field_in("qc").get_view<const Real**>();
   auto d_nc = get_field_in("nc").get_view<const Real**>();
-  auto d_qi = get_field_in("qi").get_view<const Real**>();
   auto d_cldfrac_tot = get_field_in("cldfrac_tot").get_view<const Real**>();
   auto d_rel = get_field_in("eff_radius_qc").get_view<const Real**>();
   auto d_rei = get_field_in("eff_radius_qi").get_view<const Real**>();

--- a/components/eamxx/src/physics/shoc/eamxx_shoc_process_interface.cpp
+++ b/components/eamxx/src/physics/shoc/eamxx_shoc_process_interface.cpp
@@ -64,10 +64,10 @@ void SHOCMacrophysics::create_requests()
   add_field<Updated>("surf_evap",       scalar2d    , kg/(m2*s), grid_name);
   add_field<Updated> ("T_mid",          scalar3d_mid, K,         grid_name, ps);
 
-  // qv now uses tracer-aware layout (tracer, col, lev)
+  // qv, qc now use tracer-aware layout (tracer, col, lev)
   // SCREAM_NUM_TRACERS is defined by CMake build system
-  auto qv_layout = m_grid->get_3d_tracer_layout(SCREAM_NUM_TRACERS);
-  add_field<Updated>("qv", qv_layout, kg/kg, grid_name, ps);
+  auto tracer_layout = m_grid->get_3d_tracer_layout(SCREAM_NUM_TRACERS);
+  add_field<Updated>("qv", tracer_layout, kg/kg, grid_name, ps);
 
   // If TMS is a process, add surface drag coefficient to required fields
   if (m_params.get<bool>("apply_tms", false)) {
@@ -86,7 +86,7 @@ void SHOCMacrophysics::create_requests()
   add_field<Updated>("eddy_diff_mom", scalar3d_mid, m2/s,    grid_name, ps);
   add_field<Updated>("cldfrac_liq",   scalar3d_mid, none,    grid_name, ps);
   add_tracer<Updated>("tke", m_grid, m2/s2, ps);
-  add_tracer<Updated>("qc",  m_grid, kg/kg, ps);
+  add_field<Updated>("qc", tracer_layout, kg/kg, grid_name, ps);
 
   // Output variables
   add_field<Computed>("pbl_height",       scalar2d    , m,            grid_name);
@@ -288,11 +288,12 @@ void SHOCMacrophysics::initialize_impl (const RunType run_type)
   const auto& surf_evap           = get_field_in("surf_evap").get_view<const Real*>();
   const auto& surf_mom_flux       = get_field_in("surf_mom_flux").get_view<const Real**>();
   const auto& qtracers            = get_group_out("turbulence_advected_tracers").m_monolithic_field->get_strided_view<Pack***>();
-  const auto& qc                  = get_field_out("qc").get_view<Pack**>();
 
-  // qv now has tracer dimension (tracer, col, lev) - extract slot-0 bulk water via subview
+  // qv, qc now have tracer dimension (tracer, col, lev) - extract slot-0 bulk water via subview
   const auto& qv_3d               = get_field_out("qv").get_view<Pack***>();
   const auto& qv                  = get_tracer_bulk_subview(qv_3d);
+  const auto& qc_3d               = get_field_out("qc").get_view<Pack***>();
+  const auto& qc                  = get_tracer_bulk_subview(qc_3d);
 
   const auto& tke                 = get_field_out("tke").get_view<Pack**>();
   const auto& cldfrac_liq         = get_field_out("cldfrac_liq").get_view<Pack**>();

--- a/components/eamxx/src/physics/shoc/impl/shoc_main_impl.hpp
+++ b/components/eamxx/src/physics/shoc/impl/shoc_main_impl.hpp
@@ -15,7 +15,7 @@ namespace shoc {
  * Implementation of shoc shoc_main. Clients should NOT
  * #include this file, but include shoc_functions.hpp instead.
  *
- * NOTE (Water Tracers): qv field now has tracer dimension (tracer, col, lev).
+ * NOTE (Water Tracers): qv, qc fields now have tracer dimension (tracer, col, lev).
  * Interface layer extracts slot-0 bulk water via get_tracer_bulk_subview(),
  * so kernels here receive 2D views (col, lev) and require no changes.
  */

--- a/tests/water_tracers/CMakeLists.txt
+++ b/tests/water_tracers/CMakeLists.txt
@@ -28,7 +28,17 @@ add_executable(test_qv_surface test_qv_surface.cpp)
 target_link_libraries(test_qv_surface scream_share Catch2::Catch2 Kokkos::kokkos)
 add_test(NAME test_qv_surface COMMAND test_qv_surface)
 
+# Unit tests for cloud tracer (qc, qi, qm) access (PR 3)
+# These tests validate that processes correctly access cloud tracer slot-0 from tracer-aware fields
+
+add_executable(test_cloud_tracer_access test_cloud_tracer_access.cpp)
+target_link_libraries(test_cloud_tracer_access scream_share Catch2::Catch2 Kokkos::kokkos)
+add_test(NAME test_cloud_tracer_access COMMAND test_cloud_tracer_access)
+
+add_executable(test_cloud_transport test_cloud_transport.cpp)
+target_link_libraries(test_cloud_transport scream_share Catch2::Catch2 Kokkos::kokkos)
+add_test(NAME test_cloud_transport COMMAND test_cloud_transport)
+
 # Future tests will be added here:
-# - CMake add_water_tracer function test
-# - Prototype qv_extension_test
+# - Precipitation tracer tests (PR 4)
 # - Tracer ratio validation test (PR 5)

--- a/tests/water_tracers/test_cloud_tracer_access.cpp
+++ b/tests/water_tracers/test_cloud_tracer_access.cpp
@@ -1,0 +1,164 @@
+// Unit test for cloud tracer (qc, qi, qm) access
+// Validates that processes correctly access cloud tracer slot-0 from tracer-aware fields
+
+#include "catch2/catch.hpp"
+#include "share/field/field_tracer_access.hpp"
+#include <Kokkos_Core.hpp>
+
+TEST_CASE("test_cloud_tracer_access_qc", "Test qc tracer slot-0 access") {
+  using namespace scream;
+
+  // Simulate a tracer-aware qc field (ntracers, ncols, nlevs)
+  constexpr int ntracers = 3;
+  constexpr int ncols = 10;
+  constexpr int nlevs = 72;
+
+  // Create 3D view: (tracer, col, lev)
+  Kokkos::View<Real***, Kokkos::DefaultExecutionSpace> qc_3d("qc_3d", ntracers, ncols, nlevs);
+
+  // Initialize: slot-0 = 1.0e-5, slot-1 = 2.0e-5, slot-2 = 3.0e-5
+  Kokkos::parallel_for(
+    "init_qc",
+    Kokkos::MDRangePolicy<Kokkos::Rank<3>>({0, 0, 0}, {ntracers, ncols, nlevs}),
+    KOKKOS_LAMBDA(int t, int c, int l) {
+      qc_3d(t, c, l) = static_cast<Real>((t + 1) * 1.0e-5);
+    }
+  );
+  Kokkos::fence();
+
+  // Extract bulk water (slot-0) via SUBVIEW accessor
+  auto qc_bulk = get_tracer_bulk_subview(qc_3d);
+
+  // Verify dimensions: should be (ncols, nlevs)
+  REQUIRE(qc_bulk.extent(0) == ncols);
+  REQUIRE(qc_bulk.extent(1) == nlevs);
+
+  // Verify values: all should be 1.0e-5 (slot-0)
+  auto qc_bulk_h = Kokkos::create_mirror_view(qc_bulk);
+  Kokkos::deep_copy(qc_bulk_h, qc_bulk);
+
+  for (int c = 0; c < ncols; ++c) {
+    for (int l = 0; l < nlevs; ++l) {
+      REQUIRE(qc_bulk_h(c, l) == 1.0e-5);
+    }
+  }
+}
+
+TEST_CASE("test_cloud_tracer_access_qi", "Test qi tracer slot-0 access") {
+  using namespace scream;
+
+  constexpr int ntracers = 3;
+  constexpr int ncols = 10;
+  constexpr int nlevs = 72;
+
+  Kokkos::View<Real***, Kokkos::DefaultExecutionSpace> qi_3d("qi_3d", ntracers, ncols, nlevs);
+
+  // Initialize: slot-0 = 2.0e-5, slot-1 = 4.0e-5, slot-2 = 6.0e-5
+  Kokkos::parallel_for(
+    "init_qi",
+    Kokkos::MDRangePolicy<Kokkos::Rank<3>>({0, 0, 0}, {ntracers, ncols, nlevs}),
+    KOKKOS_LAMBDA(int t, int c, int l) {
+      qi_3d(t, c, l) = static_cast<Real>((t + 1) * 2.0e-5);
+    }
+  );
+  Kokkos::fence();
+
+  auto qi_bulk = get_tracer_bulk_subview(qi_3d);
+
+  REQUIRE(qi_bulk.extent(0) == ncols);
+  REQUIRE(qi_bulk.extent(1) == nlevs);
+
+  auto qi_bulk_h = Kokkos::create_mirror_view(qi_bulk);
+  Kokkos::deep_copy(qi_bulk_h, qi_bulk);
+
+  for (int c = 0; c < ncols; ++c) {
+    for (int l = 0; l < nlevs; ++l) {
+      REQUIRE(qi_bulk_h(c, l) == 2.0e-5);
+    }
+  }
+}
+
+TEST_CASE("test_cloud_tracer_access_qm", "Test qm tracer slot-0 access") {
+  using namespace scream;
+
+  constexpr int ntracers = 3;
+  constexpr int ncols = 10;
+  constexpr int nlevs = 72;
+
+  Kokkos::View<Real***, Kokkos::DefaultExecutionSpace> qm_3d("qm_3d", ntracers, ncols, nlevs);
+
+  // Initialize: slot-0 = 3.0e-5, slot-1 = 6.0e-5, slot-2 = 9.0e-5
+  Kokkos::parallel_for(
+    "init_qm",
+    Kokkos::MDRangePolicy<Kokkos::Rank<3>>({0, 0, 0}, {ntracers, ncols, nlevs}),
+    KOKKOS_LAMBDA(int t, int c, int l) {
+      qm_3d(t, c, l) = static_cast<Real>((t + 1) * 3.0e-5);
+    }
+  );
+  Kokkos::fence();
+
+  auto qm_bulk = get_tracer_bulk_subview(qm_3d);
+
+  REQUIRE(qm_bulk.extent(0) == ncols);
+  REQUIRE(qm_bulk.extent(1) == nlevs);
+
+  auto qm_bulk_h = Kokkos::create_mirror_view(qm_bulk);
+  Kokkos::deep_copy(qm_bulk_h, qm_bulk);
+
+  for (int c = 0; c < ncols; ++c) {
+    for (int l = 0; l < nlevs; ++l) {
+      REQUIRE(qm_bulk_h(c, l) == 3.0e-5);
+    }
+  }
+}
+
+TEST_CASE("test_cloud_tracer_all_species", "Test all cloud species access patterns") {
+  using namespace scream;
+
+  constexpr int ntracers = 2;
+  constexpr int ncols = 5;
+  constexpr int nlevs = 32;
+
+  // Create all three cloud species
+  Kokkos::View<Real***, Kokkos::DefaultExecutionSpace> qc_3d("qc_3d", ntracers, ncols, nlevs);
+  Kokkos::View<Real***, Kokkos::DefaultExecutionSpace> qi_3d("qi_3d", ntracers, ncols, nlevs);
+  Kokkos::View<Real***, Kokkos::DefaultExecutionSpace> qm_3d("qm_3d", ntracers, ncols, nlevs);
+
+  // Initialize with unique values for each species
+  Kokkos::parallel_for(
+    "init_all",
+    Kokkos::MDRangePolicy<Kokkos::Rank<3>>({0, 0, 0}, {ntracers, ncols, nlevs}),
+    KOKKOS_LAMBDA(int t, int c, int l) {
+      qc_3d(t, c, l) = 1.0e-4 + t * 0.1e-4;
+      qi_3d(t, c, l) = 2.0e-4 + t * 0.2e-4;
+      qm_3d(t, c, l) = 3.0e-4 + t * 0.3e-4;
+    }
+  );
+  Kokkos::fence();
+
+  // Extract bulk water for all species
+  auto qc_bulk = get_tracer_bulk_subview(qc_3d);
+  auto qi_bulk = get_tracer_bulk_subview(qi_3d);
+  auto qm_bulk = get_tracer_bulk_subview(qm_3d);
+
+  // Verify dimensions
+  REQUIRE(qc_bulk.extent(0) == ncols);
+  REQUIRE(qi_bulk.extent(0) == ncols);
+  REQUIRE(qm_bulk.extent(0) == ncols);
+
+  // Verify slot-0 values
+  auto qc_bulk_h = Kokkos::create_mirror_view(qc_bulk);
+  auto qi_bulk_h = Kokkos::create_mirror_view(qi_bulk);
+  auto qm_bulk_h = Kokkos::create_mirror_view(qm_bulk);
+  Kokkos::deep_copy(qc_bulk_h, qc_bulk);
+  Kokkos::deep_copy(qi_bulk_h, qi_bulk);
+  Kokkos::deep_copy(qm_bulk_h, qm_bulk);
+
+  for (int c = 0; c < ncols; ++c) {
+    for (int l = 0; l < nlevs; ++l) {
+      REQUIRE(qc_bulk_h(c, l) == 1.0e-4);
+      REQUIRE(qi_bulk_h(c, l) == 2.0e-4);
+      REQUIRE(qm_bulk_h(c, l) == 3.0e-4);
+    }
+  }
+}

--- a/tests/water_tracers/test_cloud_transport.cpp
+++ b/tests/water_tracers/test_cloud_transport.cpp
@@ -1,0 +1,203 @@
+// Component test for cloud tracer transport
+// Validates that cloud tracer mass is conserved during transport operations
+
+#include "catch2/catch.hpp"
+#include "share/field/field_tracer_access.hpp"
+#include <Kokkos_Core.hpp>
+
+TEST_CASE("test_cloud_transport_conservation", "Test cloud tracer mass conservation") {
+  using namespace scream;
+
+  // Simulate a simple transport: move cloud water from one level to another
+  constexpr int ntracers = 3;
+  constexpr int ncols = 10;
+  constexpr int nlevs = 72;
+
+  // Create qc field
+  Kokkos::View<Real***, Kokkos::DefaultExecutionSpace> qc_3d("qc_3d", ntracers, ncols, nlevs);
+
+  // Initialize: tracer 0 (bulk) = 1.0e-4, tracer 1 = 0.5e-4 (half of bulk), tracer 2 = 0.25e-4
+  Kokkos::parallel_for(
+    "init_qc",
+    Kokkos::MDRangePolicy<Kokkos::Rank<3>>({0, 0, 0}, {ntracers, ncols, nlevs}),
+    KOKKOS_LAMBDA(int t, int c, int l) {
+      if (t == 0) {
+        qc_3d(t, c, l) = 1.0e-4;
+      } else if (t == 1) {
+        qc_3d(t, c, l) = 0.5e-4;
+      } else {
+        qc_3d(t, c, l) = 0.25e-4;
+      }
+    }
+  );
+  Kokkos::fence();
+
+  // Compute initial total mass for each tracer
+  Kokkos::View<Real*, Kokkos::DefaultExecutionSpace> initial_mass("initial_mass", ntracers);
+  Kokkos::parallel_for(
+    "compute_initial_mass",
+    Kokkos::MDRangePolicy<Kokkos::Rank<3>>({0, 0, 0}, {ntracers, ncols, nlevs}),
+    KOKKOS_LAMBDA(int t, int c, int l) {
+      Kokkos::atomic_add(&initial_mass(t), qc_3d(t, c, l));
+    }
+  );
+  Kokkos::fence();
+
+  // Simulate a transport operation: proportional transport
+  // Move 10% of cloud water from level l to level l+1 (where l+1 exists)
+  Kokkos::parallel_for(
+    "transport",
+    Kokkos::MDRangePolicy<Kokkos::Rank<3>>({0, 0, 0}, {ntracers, ncols, nlevs - 1}),
+    KOKKOS_LAMBDA(int t, int c, int l) {
+      Real transport_amount = 0.1 * qc_3d(t, c, l);
+      qc_3d(t, c, l) -= transport_amount;
+      qc_3d(t, c, l + 1) += transport_amount;
+    }
+  );
+  Kokkos::fence();
+
+  // Compute final total mass for each tracer
+  Kokkos::View<Real*, Kokkos::DefaultExecutionSpace> final_mass("final_mass", ntracers);
+  Kokkos::parallel_for(
+    "compute_final_mass",
+    Kokkos::MDRangePolicy<Kokkos::Rank<3>>({0, 0, 0}, {ntracers, ncols, nlevs}),
+    KOKKOS_LAMBDA(int t, int c, int l) {
+      Kokkos::atomic_add(&final_mass(t), qc_3d(t, c, l));
+    }
+  );
+  Kokkos::fence();
+
+  // Verify mass conservation: initial_mass == final_mass for each tracer
+  auto initial_mass_h = Kokkos::create_mirror_view(initial_mass);
+  auto final_mass_h = Kokkos::create_mirror_view(final_mass);
+  Kokkos::deep_copy(initial_mass_h, initial_mass);
+  Kokkos::deep_copy(final_mass_h, final_mass);
+
+  for (int t = 0; t < ntracers; ++t) {
+    // Mass should be conserved to machine precision
+    REQUIRE(std::abs(initial_mass_h(t) - final_mass_h(t)) < 1.0e-14 * initial_mass_h(t));
+  }
+}
+
+TEST_CASE("test_cloud_tracer_ratio_preservation", "Test tracer ratios preserved during transport") {
+  using namespace scream;
+
+  constexpr int ntracers = 3;
+  constexpr int ncols = 10;
+  constexpr int nlevs = 72;
+
+  // Create qc field with known tracer ratios
+  Kokkos::View<Real***, Kokkos::DefaultExecutionSpace> qc_3d("qc_3d", ntracers, ncols, nlevs);
+
+  // Initialize with specific ratios: tracer_1 / tracer_0 = 0.5, tracer_2 / tracer_0 = 0.25
+  Kokkos::parallel_for(
+    "init_qc",
+    Kokkos::MDRangePolicy<Kokkos::Rank<3>>({0, 0, 0}, {ntracers, ncols, nlevs}),
+    KOKKOS_LAMBDA(int t, int c, int l) {
+      Real base_value = 1.0e-4 * (1 + c * 0.1) * (1 + l * 0.01);  // Vary by column and level
+      if (t == 0) {
+        qc_3d(t, c, l) = base_value;
+      } else if (t == 1) {
+        qc_3d(t, c, l) = 0.5 * base_value;
+      } else {
+        qc_3d(t, c, l) = 0.25 * base_value;
+      }
+    }
+  );
+  Kokkos::fence();
+
+  // Simulate proportional transport (preserves ratios)
+  // Move 20% from level l to level l+1
+  Kokkos::parallel_for(
+    "transport",
+    Kokkos::MDRangePolicy<Kokkos::Rank<3>>({0, 0, 0}, {ntracers, ncols, nlevs - 1}),
+    KOKKOS_LAMBDA(int t, int c, int l) {
+      Real transport_amount = 0.2 * qc_3d(t, c, l);
+      qc_3d(t, c, l) -= transport_amount;
+      qc_3d(t, c, l + 1) += transport_amount;
+    }
+  );
+  Kokkos::fence();
+
+  // Verify tracer ratios are preserved
+  auto qc_3d_h = Kokkos::create_mirror_view(qc_3d);
+  Kokkos::deep_copy(qc_3d_h, qc_3d);
+
+  for (int c = 0; c < ncols; ++c) {
+    for (int l = 0; l < nlevs; ++l) {
+      Real bulk = qc_3d_h(0, c, l);
+      if (bulk > 1.0e-20) {  // Avoid division by zero
+        Real ratio_1 = qc_3d_h(1, c, l) / bulk;
+        Real ratio_2 = qc_3d_h(2, c, l) / bulk;
+
+        // Ratios should be preserved: 0.5 and 0.25
+        REQUIRE(std::abs(ratio_1 - 0.5) < 1.0e-12);
+        REQUIRE(std::abs(ratio_2 - 0.25) < 1.0e-12);
+      }
+    }
+  }
+}
+
+TEST_CASE("test_cloud_qi_transport", "Test qi tracer transport") {
+  using namespace scream;
+
+  constexpr int ntracers = 2;
+  constexpr int ncols = 5;
+  constexpr int nlevs = 32;
+
+  Kokkos::View<Real***, Kokkos::DefaultExecutionSpace> qi_3d("qi_3d", ntracers, ncols, nlevs);
+
+  // Initialize with uniform distribution
+  Kokkos::parallel_for(
+    "init_qi",
+    Kokkos::MDRangePolicy<Kokkos::Rank<3>>({0, 0, 0}, {ntracers, ncols, nlevs}),
+    KOKKOS_LAMBDA(int t, int c, int l) {
+      qi_3d(t, c, l) = (t == 0) ? 2.0e-4 : 1.0e-4;
+    }
+  );
+  Kokkos::fence();
+
+  // Compute initial total for each tracer
+  Kokkos::View<Real*, Kokkos::DefaultExecutionSpace> initial_total("initial_total", ntracers);
+  Kokkos::parallel_for(
+    "sum_initial",
+    Kokkos::MDRangePolicy<Kokkos::Rank<3>>({0, 0, 0}, {ntracers, ncols, nlevs}),
+    KOKKOS_LAMBDA(int t, int c, int l) {
+      Kokkos::atomic_add(&initial_total(t), qi_3d(t, c, l));
+    }
+  );
+  Kokkos::fence();
+
+  // Simulate sedimentation: move 5% downward
+  Kokkos::parallel_for(
+    "sediment",
+    Kokkos::MDRangePolicy<Kokkos::Rank<3>>({0, 0, 0}, {ntracers, ncols, nlevs - 1}),
+    KOKKOS_LAMBDA(int t, int c, int l) {
+      Real sed_amount = 0.05 * qi_3d(t, c, l);
+      qi_3d(t, c, l) -= sed_amount;
+      qi_3d(t, c, l + 1) += sed_amount;
+    }
+  );
+  Kokkos::fence();
+
+  // Compute final total
+  Kokkos::View<Real*, Kokkos::DefaultExecutionSpace> final_total("final_total", ntracers);
+  Kokkos::parallel_for(
+    "sum_final",
+    Kokkos::MDRangePolicy<Kokkos::Rank<3>>({0, 0, 0}, {ntracers, ncols, nlevs}),
+    KOKKOS_LAMBDA(int t, int c, int l) {
+      Kokkos::atomic_add(&final_total(t), qi_3d(t, c, l));
+    }
+  );
+  Kokkos::fence();
+
+  // Verify conservation
+  auto initial_h = Kokkos::create_mirror_view(initial_total);
+  auto final_h = Kokkos::create_mirror_view(final_total);
+  Kokkos::deep_copy(initial_h, initial_total);
+  Kokkos::deep_copy(final_h, final_total);
+
+  for (int t = 0; t < ntracers; ++t) {
+    REQUIRE(std::abs(initial_h(t) - final_h(t)) < 1.0e-14 * initial_h(t));
+  }
+}


### PR DESCRIPTION
## Summary
- Extend cloud water fields (qc, qi, qm) from shape (col, lev) to (tracer, col, lev)
- Apply SUBVIEW accessor pattern established in PRs 2a-2d
- Update 5 physics processes: P3, SHOC, Cloud Fraction, RRTMGP, MAM
- Add unit tests and component tests for cloud tracer access

## Deliverables
- P3: qc, qi, qm now use tracer-aware layout
- SHOC: qc now uses tracer-aware layout
- Cloud Fraction: qi now uses tracer-aware layout (note: Python interface may need update)
- RRTMGP: qc, qi now use tracer-aware layout
- MAM: qv, qc, qi now use tracer-aware layout (qv also updated, not done in PR 2d)
- Unit tests: test_cloud_tracer_access.cpp
- Component tests: test_cloud_transport.cpp

## Test plan
- [ ] Compile with SCREAM_NUM_TRACERS=1
- [ ] Compile with SCREAM_NUM_TRACERS=3
- [ ] Run unit test: test_cloud_tracer_access
- [ ] Run component test: test_cloud_transport
- [ ] Run P3 standalone BFB test vs pre-campaign baseline
- [ ] Run SHOC standalone BFB test vs pre-campaign baseline
- [ ] Run full EAMxx test suite BFB vs pre-campaign baseline

## Part of campaign
Part 6 of 8 of campaign 2026-05-29-wiso-group1-revised

Stacked on #7 (PR 5/8 - spec 2d: Remaining processes)